### PR TITLE
Remove duplicated h1 headings where semantic subheadings are appropriate...

### DIFF
--- a/css/app/sponsors.css
+++ b/css/app/sponsors.css
@@ -12,16 +12,16 @@
     text-decoration: none !important;
 }
 
-
 /* Different max sizes for different levels */
+
+
+.logo {
+    padding:0 10px 10px 0;    
+}
 
 .platinum img.logo {
     max-width: 100%;
     max-height: 200px;
-}
-
-#sponsors #main-content .platinum h2 {
-    height: 200px;
 }
 
 .gold img.logo {
@@ -29,17 +29,9 @@
     max-height: 100px;
 }
 
-#sponsors #main-content .gold h2 {
-    height: 100px;
-}
-
 .silver img.logo {
     max-width: 100%;
     max-height: 75px;
-}
-
-#sponsors #main-content .silver h2 {
-    height: 75px;
 }
 
 .bronze img.logo {
@@ -47,15 +39,10 @@
     max-height: 50px;
 }
 
-#sponsors #main-content .bronze h2 {
-    height: 50px;
-}
+#sponsors #main-content .bronze h2 {}
 
 .thanks img.logo {
     max-width: 100%;
     max-height: 50px;
 }
 
-#sponsors #main-content .thanks h2 {
-    height: 50px;
-}

--- a/sponsors/2013.html
+++ b/sponsors/2013.html
@@ -7,23 +7,20 @@ body_id: sponsors
 <div class="col-md-12">
   <div class="hero-unit">
     <h1>SeaGL 2013 Sponsors</h1>
-    <p>Our community sponsors are the lifeblood of SeaGL and we can't thank them enough. Their contributions have a real and lasting effect in the FLOSS community. Thank you all.</p>
-    <p>&nbsp;</p>
-    <p>&nbsp;</p>
-    <p>&nbsp;</p>
+    <p class="lead text-center">Our community sponsors are the lifeblood of SeaGL and we can't thank them enough. <br class="hidden-xs hidden-sm" /> Their contributions have a real and lasting effect in the FLOSS community. Thank you all.</p>
   </div>
-  
+
   <div class="row platinum">
-    <h1>Platinum</h1>
+    <h2>Platinum</h2>
     
     <div class="col-md-6">
-      <h2><a href="http://seattlecentral.edu/sccc/"><img class="logo" src="/img/sponsors/SCCC/sccc_hrz_2c_ko_ff.png"></a></h2>
+      <h3><a href="http://seattlecentral.edu/sccc/"><img class="logo" src="/img/sponsors/SCCC/sccc_hrz_2c_ko_ff.png"></a></h3>
       <p>Seattle Central Community College is located on Capitol Hill, the vibrant urban center of Seattle life. We are an educational home for our students, a leadership incubator for our community and an economic catalyst for our state and beyond. Since 1966, the college has served the higher education and workforce training needs of more than 500,000 students.</p>
       <p>Seattle Central is committed to creating a learning environment that is accessible, diverse, responsive, and innovative.</p>
     </div>
     
     <div class="col-md-6">
-      <h2><a href="http://www.siliconmechanics.com/"><img class="logo" src="/img/sponsors/SiliconMechanics/SiMechTrimmed.png"></a></h2>
+      <h3><a href="http://www.siliconmechanics.com/"><img class="logo" src="/img/sponsors/SiliconMechanics/SiMechTrimmed.png"></a></h3>
       <p>Silicon Mechanics is an industry-leading provider of server, storage, and high-performance computing solutions. Deploying the latest innovations in hardware and software technology, we work in collaboration with our customers to design and build the most efficient, cost-effective technology solution for their needs. Our guiding principle, "Expert included," is our promise that reflects our passion for complete customer satisfaction, from server and component selection to superior installation and ongoing technical support.</p>
     </div>
   </div>
@@ -31,14 +28,14 @@ body_id: sponsors
   <hr>
   
   <div class="row gold">
-    <h1>Gold</h1>
+    <h2>Gold</h2>
     <div class="col-md-6">
-      <h2><a href="http://www.schedulesdirect.org/"><img class="logo" src="/img/sponsors/SchedulesDirect/sd_long.png"></a></h2>
+      <h3><a href="http://www.schedulesdirect.org/"><img class="logo" src="/img/sponsors/SchedulesDirect/sd_long.png"></a></h3>
       <p>Schedules Direct is a non-profit organization whose mission is to educate the public about the benefits of Open Source Software and other free software, provide support functions for such software, and provide funding for research that facilitates the improvement or creation of Open Source Software and other free software for the benefit of the public at large.</p>
     </div>
     
     <div class="col-md-6">
-      <h2><a href="http://www.rackspace.com/"><img class="logo" src="/img/sponsors/Rackspace/Rackspace_Cloud_Company_Logo_clr.png"></a></h2>
+      <h3><a href="http://www.rackspace.com/"><img class="logo" src="/img/sponsors/Rackspace/Rackspace_Cloud_Company_Logo_clr.png"></a></h3>
       <p>Fanatical Support® has made Rackspace the service leader in cloud computing. We deliver enterprise-class hybrid cloud infrastructures to businesses of all sizes and kinds around the world. We started in 1998 and we host hundreds of thousands of customers worldwide. Rackspace combines public cloud, private cloud, and dedicated bare metal computing to provide the perfect infrastructure for each customer’s specific needs. And, the Rackspace Hybrid Cloud is powered by OpenStack® and backed by Fanatical Support. </p>
     </div>
   </div>
@@ -46,14 +43,14 @@ body_id: sponsors
   <hr>
   
   <div class="row bronze">
-    <h1>Bronze</h1>
+    <h2>Bronze</h2>
     <div class="col-md-6">
-      <h2><a href="http://www.pogolinux.com/"><img class="logo" src="/img/sponsors/PogoLinux/logo_pogolinux.png"></a></h2>
+      <h3><a href="http://www.pogolinux.com/"><img class="logo" src="/img/sponsors/PogoLinux/logo_pogolinux.png"></a></h3>
       <p>Founded in 1999, Pogo Linux, Inc. is an open-source systems integrator based out of Seattle, WA. With a multi-OS focus and in-house technical expertise, we offer a wide range of workstations, servers and network storage solutions for the technology needs of IT departments in organizations of all sizes.</p>
     </div>
     
     <div class="col-md-6">
-      <h2><a href="http://hpcloud.com"><img class="logo" src="/img/sponsors/HPCloud/HP_Blue_RGB_150_MX.png"></a></h2>
+      <h3><a href="http://hpcloud.com"><img class="logo" src="/img/sponsors/HPCloud/HP_Blue_RGB_150_MX.png"></a></h3>
       <p>Hewlett-Packard is long term supporter of Linux and of Open Source.  HP is a Platinum member of the Linux Foundation and a Founding and Platinum member of the OpenStack Foundation.  HP ships a new Linux server every minute, and operates an OpenStack public cloud at <a href="http://hpcloud.com">http://hpcloud.com</a></p>
     </div>
   </div>
@@ -61,23 +58,22 @@ body_id: sponsors
   <hr>
   
   <div class="row thanks">
-    <h1>Special Thanks To</h1>
+    <h2>Special Thanks To</h2>
     <div class="col-md-6">
-      <h2><a href="http://www.gslug.org/"><img class="logo" src="/img/sponsors/GSLUG/logo.png"></a></h2>
+      <h3><a href="http://www.gslug.org/"><img class="logo" src="/img/sponsors/GSLUG/logo.png"></a></h3>
       <p>The Greater Seattle Linux Users Group is a local organization of people in the Seattle Metropolitan area that wish to collaborate on subjects pertaining to Linux and Open Source Software in general. Monthly meetings since 1994 and an active mailing list help to make this possible.</p>
       <p>GSLUG is a Linux Users Group, which means it's mainly comprised of people who use Linux on a day-to-day basis for work and fun, and it is also the premier place for people to come and learn more about Linux and Open Source Software, whether you've never used Linux before, or if you're a seasoned kernel developer, GSLUG is an excellent place to meet new people, learn things you never knew before, and share great ideas.</p>
     </div>
     
     <div class="col-md-6">
-      <h2><a href="http://www.linuxjournal.com/"><img class="logo" src="/img/sponsors/LinuxJournal/ljcolor.png"></a></h2>
+      <h3><a href="http://www.linuxjournal.com/"><img class="logo" src="/img/sponsors/LinuxJournal/ljcolor.png"></a></h3>
       <p>Linux Journal, currently celebrating its 19th year of publication, is the original magazine of the global Linux community, delivering readers the advice and inspiration they need to get the most out of their Linux systems.</p>
     </div>
     
     <div class="col-md-6">
-      <h2><a href="http://www.unixstuff.net/">UnixStuff</a></h2>
+      <h3><a href="http://www.unixstuff.net/">UnixStuff</a></h3>
       <p>UnixStuff provides a large selection of Linux stickers for you to put onto your keyboard or computer casing to show off your Linux operating system!</p>
     </div>
-    
+  
   </div>
   
-  <hr>


### PR DESCRIPTION
. Also removing margins and heights for a given sponsor block when the max-size for logos will suffice. It won't take into account line-height and will get funky going forward, and besides, it creates a ton of extra whitespace and makes the vertical rhythm look janky.

I changed the headings because you should avoid using more than one h1 tag for a given page, and it also breaks the idea of semantic subheadings, of which these definitely are. The prominence of a given sponsor block is denoted by the size of the logos themselves, so I think that approach is sufficient.

Cheers!
