### PR TITLE
name the code of conduct link more clearly

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,9 @@
       </div>
       <div class="well" id="policy-content">
         <img src="/img/seagl-cropped.svg" class="pull-left" alt="Logo" width="306" height="200">
-        <p>SeaGL is dedicated to a harassment-free conference experience for everyone. <br class="hidden-sm">Our anti-harassment policy can be found <a href="/code_of_conduct.html">here</a></p>
+        <p>SeaGL is dedicated to a harassment-free conference experience for
+        everyone. <br class="hidden-sm">Our code of conduct can be found 
+        <a href="/code_of_conduct.html">here</a></p>
       </div>
       <footer>
         <ul id="footer-nav" role="navigation" class="list-inline">


### PR DESCRIPTION
Because during the last meeting, I searched for 'conduct' on the front page and found nothing. Also the contrast on that footer is pretty poor and might be difficult for those with visual challenges, so making it searchable improves accessibility.