### PR TITLE
Fixes #37. Removed Cascadia award section and added volunteer info

### DIFF
--- a/_posts/2015-10-13-QA-aaronwolf.md
+++ b/_posts/2015-10-13-QA-aaronwolf.md
@@ -1,0 +1,65 @@
+---
+layout: post
+title: 'SeaGL speaker Q&A: Aaron Wolf'
+status: publish
+type: post
+published: true
+categories: news
+---
+
+SeaGL speaker Aaron Wolf talks about making music with free/libre/open tools:
+
+Q: Could you please introduce yourself and tell us a little about your 
+background?
+
+I'm a musician and music teacher. I used to use Apple computers and was
+introduced to software freedom as a user of GPL software such as
+Musescore and Audacity. As more of my students started using iThings, I
+initially hoped to see such tools there. Instead, I learned that Apple
+made terms that censored out GPL software, and instead iThings were left
+with a proprietary walled-garden where even a simple guitar tuner app gets
+injected with obnoxious advertisements.
+
+I switched to GNU/Linux in January 2012, and that brought me tons of new
+perspectives and led to co-founding an ambitious new project that has
+taken over my life: Snowdrift.coop is a free-software, free-culture
+fundraising platform that aims to better coordinate the global community
+to fund deserving projects that respect our freedoms. The core idea is a
+network-matching pledge in which a patron of a project can say "I will
+donate more each month for each additional patron who will support this
+project with me." The details are a talk in itself, but interested folks
+can visit the site at Snowdrift.coop.
+
+I continue using GNU/Linux while making a modest living teaching private
+music lessons. Where feasible, I promote the issues of software freedom
+to my students and encourage them to move to GNU/Linux.
+
+Q: Without tipping your hand on the actual talk, can you give us an
+idea of what we might expect?
+
+My talk will simply be a tour through the basics of music production on
+GNU/Linux. We'll cover basics about hardware setup, latency, JACK, ALSA,
+and such. I'll mention repos and community websites. Then, we'll explore
+some simple introductions to the most user-friendly music software:
+Audacity, Ardour, Musescore, Guitarix, Hydrogen, the Cadence Suite, and
+more. We'll be making some new music on the fly to demonstrate these tools.
+
+Q: Is this your first visit to SeaGL? If so, what are your expectations? If
+not, can you give us your impressions of the event?
+
+This is my first visit to SeaGL. I expect it will be something like
+LinuxFest Northwest with a little more emphasis on GNU. I know many of
+the people involved.
+
+I hope that it will attract diverse attendees both in terms of things
+like gender and cultural background and in terms of interests and
+occupations. However, I won't be surprised if there's the common
+unfortunate heavy white male programmer / sysadmin dominance — after
+all, it's a GNU/Linux conference. I also hope that the emphasis on
+software freedom and GNU bring out clear political messages about the
+importance of building a free society rather than the typical tech
+conference focus on just the technology itself.
+
+Besides my talk, I look forward to continue recruiting more folks to
+help with Snowdrift.coop, and I'm sure I'll see a mix of familiar faces
+and also meet new supportive people.

--- a/get_involved.html
+++ b/get_involved.html
@@ -9,29 +9,13 @@ body_id: get-involved
 <div class="col-md-12">
   <div class="row">
     <div class="col-md-8">
-        <h2>Nominate candidates for Cascadia Community Builder award</h2>
+        <h2>Volunteer for SeaGL</h2>
         <p>
-            This is a new award for a person who has made an outstanding
-            contribution to the free software movement in Washington, Oregon,
-            British Columbia and Idaho. This award will be given to someone
-            for their work to build the free software community over the last
-            one to three years. The winner of this award will be someone who
-            has have applied deep commitment and creativity to growing and
-            broadening the community.  The award is designed to recognize work
-            in software projects, non-profit organizations, outreach and
-            education, hackerspace, user groups or any activity that promotes
-            the adoption and appreciation of free software to new and larger
-            groups of people. The awards committee is especially interested in
-            individuals who have successfully reached out to traditionally
-            under-represented groups, even if that is not the primary goal.
-                                                                                            
-            To nominate someone, please send us an email <a
-                href="mailto:%61%77%61%72%64%40%73%65%61%67%6c%2e%6f%72%67">&#x0061;&#x0077;&#x0061;&#x0072;&#x0064;&#x0040;&#x0073;&#x0065;&#x0061;&#x0067;&#x006c;&#x002e;&#x006f;&#x0072;&#x0067;</a>
-            with the nominee's name in the subject line. The more information
-            you can provide about the nominee's work, affiliations and history
-            with free software, the better. Thanks in advance for helping us
-            honor a great community builder!
-                                                                                            
+            We're looking for volunteers to assist with various tasks during the
+            days of the conference. We need help directing attendees to rooms,
+            helping speakers get set up, and fulfilling other random roles. If 
+            you'd like to help out, email us at <a
+                href="mailto:participate@seagl.org">participate@seagl.org</a>.
         </p>
         <h2>Sponsors and Non-Profit Exhibitors</h2>
         <p>


### PR DESCRIPTION
Updated the get_involved.html file to delete the Cascadia award information. I also added information for volunteering.