### PR TITLE
explicitly specify highlighter in config to suppress build warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ lsi:            false
 pygments:       true
 timezone:       America/Los_Angeles
 markdown:       kramdown
+highlighter:    rouge
 
 paginate:       10
 paginate_path:  "news/page:num"


### PR DESCRIPTION
When building the site the following warning is issued by GitHub:

```
    The page build completed successfully, but returned the following warning:

    You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.

    For information on troubleshooting Jekyll see:

      https://help.github.com/articles/troubleshooting-jekyll-builds

    If you have any questions you can contact us by replying to this email.
```

This patch adds the recommended config to suppress the warning. See also GitHub's documentation for this: https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.