### PR TITLE
Change Schedule menu item to CFP

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -14,7 +14,7 @@
   <div id="main-nav-container" class="collapse navbar-collapse top-nav-collapse">
     <ul class="nav pull-left navbar-nav main-nav-links inline-list">
       <li {% if page.nav == "home" %} class="active" | {% endif %} ><a href="/">Home</a></li>
-      <li><a href="https://osem.seagl.org/conference/seagl2016/schedule">Schedule</a></li>
+      <li><a href="http://seagl.org/news/2017/06/19/CFP-open.html">CFP</a></li>
       <!-- <li {% if page.nav == "schedule" %} class="active" | {% endif %} ><a href="/schedule/{{ site.custom.year }}.html">Schedule</a></li> -->
     </ul>
 


### PR DESCRIPTION
We don't have a schedule yet, but we *do* have a CFP open right now. It needs more exposure, so I've switched the 'Schedules' link from the header to be 'CFP'. It points to the announcement blog post, as that has the best information for the CFP. I don't like that there's an acronym in the link text, but "Call For Proposals" wrapped & messed up the header layout.

This would also handle issue #88.