### PR TITLE
fix sponsors link

### DIFF
--- a/sponsors/2018.html
+++ b/sponsors/2018.html
@@ -1,0 +1,7 @@
+---
+layout: sponsors
+nav: sponsors
+body_id: sponsors
+
+year: 2018
+---

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -7,6 +7,9 @@ body_id: sponsors
 <div class="col-md-12">
   <div class="hero-unit">
     <h1>SeaGL Sponsors</h1>
+    <h2><a href="/sponsors/2018.html">SeaGL 2018 Sponsors</a></h2>
+    <h2><a href="/sponsors/2017.html">SeaGL 2017 Sponsors</a></h2>
+    <h2><a href="/sponsors/2016.html">SeaGL 2016 Sponsors</a></h2>
     <h2><a href="/sponsors/2015.html">SeaGL 2015 Sponsors</a></h2>
     <h2><a href="/sponsors/2014.html">SeaGL 2014 Sponsors</a></h2>
     <h2><a href="/sponsors/2013.html">SeaGL 2013 Sponsors</a></h2>


### PR DESCRIPTION
In header and elsewhere (2018 was missing).

Also add not yet added years to `/sponsors` index.

Notes/possible followup issues:

- 2018 prospectus not online
- Would be possible to change `_layouts/sponsors.html` so that if no current sponsors (like 2018) instead of showing blank levels, link to `/sponsors` thanking past sponsors or something like that.