### PR TITLE
Clarify that registration is not required to attend

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,13 @@ description: SeaGL is a grassroots technical conference dedicated to spreading a
             at {{ site.custom.a.location }} (<a href="/maps/{{ site.custom.year }}.html">Maps</a>). <strong>9am-5:30pm both days.</strong>
         </p>
         <p>
+            <strong>You do not need to register for SeaGL - just show up! The cost of attendance is free.</strong>
+        </p>
+        <p>
+            <strong>You may attend SeaGL without identifying yourself, and you are encouraged to do so to protect your privacy.</strong>
+        </p>
+        <p><strong><a href="https://osem.seagl.org/">You may optionally register</a>. This gives us attendee counts, which help us raise money for SeaGL conferences. The registration system is Free/Libre/Open Source Software and we promise to protect your data.</strong><p>
+        <p>
             SeaGL is a grassroots technical conference dedicated to spreading
             awareness and knowledge about the GNU/Linux community and
             free/libre/open-source software/hardware. Our goal for SeaGL is to
@@ -35,15 +42,6 @@ description: SeaGL is a grassroots technical conference dedicated to spreading a
             The SeaGL web site is built with <a href="https://jekyllrb.com/">
             Jekyll</a> and we use <a href="http://osem.io/">OSEM</a> for event
             management.
-        </p>
-        <p>
-            <strong>The cost of attendance is free.</strong>
-        </p>
-        <p>
-            <strong><a href="https://osem.seagl.org">Attendee Registration</a> will not require the use of non-free software.</strong>
-        </p>
-        <p>
-            <strong>You may attend SeaGL without identifying yourself, and you are encouraged to do so to protect your privacy.</strong>
         </p>
     </div>
   </div>


### PR DESCRIPTION
This adds a note that attendees do not have to register to attend SeaGL,
and moves this memo along with the anonymity higher in the About sidebar
as well, for visibility