### PR TITLE
added blank target for sponsor links

### DIFF
--- a/_layouts/sponsors.html
+++ b/_layouts/sponsors.html
@@ -31,7 +31,7 @@ levels:
           {% if year[0] == page.year and year[1] == level[0] %}
             <div class="col-md-6">
               <h3>
-                <a href="{{ sponsor.url }}">
+                <a href="{{ sponsor.url }}" target="_blank">
                   {% if sponsor.logo.banner != "missing" %}
                     <img class="logo" src="{{ sponsor.logo.banner }}" alt="{{ sponsor.name }}">
                   {% elsif sponsor.logo.square != "missing" %}
@@ -39,6 +39,7 @@ levels:
                   {% else %}
                     <div class="name">{{ sponsor.name }}</div>
                   {% endif %}
+                  
                 </a>
               </h3>
             </div>


### PR DESCRIPTION
While I was testing the security patch this morning I noticed that our sponsor links take the users away from our site vs having a target = blank to open in a new tab. This will keep SeaGL open in the users browsers. :) 