### PR TITLE
Add configuration for visual regression testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ _site
 .jekyll-metadata
 .vagrant
 
+# BackstopJS
+/backstop/reports/
+/backstop/results/
+
 .DS_Store
 
 # IDE stuff

--- a/README.md
+++ b/README.md
@@ -89,42 +89,62 @@ TBD (assumption is those using git on their local machines already know this; **
 
 ## Test your changes
 
-Please test-drive all changes locally before pushing to GitHub. There are a few ways to run a Jekyll test server locally. Take your pick!
+Please test-drive all changes locally before pushing to GitHub.
 
-1. bare metal
-1. virtual machine
-1. containerized
+### Local development server
 
-### Local dev - bare metal
+Starting a local development server will make your copy of the site available at <http://localhost:4000>. There are a few ways to run the server. Take your pick!
 
-1. Install Jekyll Gem (and it's dependencies) `gem install jekyll`.
-2. Serve with Jekyll `jekyll serve --watch`.
-    * The optional `--watch` argument watches files for changes and automatically rebuilds everything in \_site when they do.
-3. Navigate to <http://localhost:4000>.
+#### Option 1: Bare metal
 
-### Local dev - virtual machine
+Dependencies:
 
-Use the `Vagrantfile`.
+  - [Ruby](https://www.ruby-lang.org/)
+  - [Bundler](https://bundler.io/)
 
-### Local dev - containerized
-
-[Install Docker](https://docs.docker.com/engine/installation/).
-
-**Once** (or when build scripts change): build a Docker image for local dev with
+One-time setup:
 
 ```bash
-docker build -t seagldev .
+bundle install
 ```
 
-**Every time**: start your dev container with
+Start the server:
 
 ```bash
-docker run -p 4000:4000 --rm -it -v "$PWD":/usr/src/app seagldev
+bundle exec jekyll serve --watch
 ```
 
-View the rendered website at <http://localhost:4000> on your host.
+#### Option 2: Virtual machine
 
-Edit files on your host and reload to see changes.
+Dependencies:
+
+  - [Vagrant](https://www.vagrantup.com/)
+
+Start the server:
+
+```bash
+vagrant up
+```
+
+#### Option 3: Containerized
+
+Dependencies:
+
+  - [Docker](https://docs.docker.com/)
+
+One-time setup:
+
+```bash
+docker build --tag 'seagldev' '.'
+```
+
+Start the server:
+
+```bash
+docker run --rm --interactive --tty --publish '4000:4000' --volume "$PWD:/usr/src/app" 'seagldev'
+```
+
+
 
 ## Send a pull request (PR) for the changes
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ Please test-drive all changes locally before pushing to GitHub. There are a few 
 1. virtual machine
 1. containerized
 
-To see the map on `/maps/2019.html` you must hand-edit absolute URLs in `map-data/scc_2019-11-04/osm-liberty/styles.custom.json` starting with `https://seagl.org`. For example, if you use the Docker method below for local dev, change `"https://seagl.org/map-data/scc_2019-11-04/tiles/{z}/{x}/{y}.pbf"` to `"http://localhost:4000/map-data/scc_2019-11-04/tiles/{z}/{x}/{y}.pbf"`. This _should_ be automatable with `jekyll`; please consider sending us a patch if you know how to do this!
-
 ### Local dev - bare metal
 
 1. Install Jekyll Gem (and it's dependencies) `gem install jekyll`.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,25 @@ Start the server:
 docker run --rm --interactive --tty --publish '4000:4000' --volume "$PWD:/usr/src/app" 'seagldev'
 ```
 
+### Visual regression testing
 
+When making changes that might have site-wide effects (e.g. editing stylesheets, restructuring templates, or updating dependencies) it can be useful to see a visual comparison of before and after screenshots.
+
+Dependencies:
+
+  - [BackstopJS](https://github.com/garris/BackstopJS)
+
+One-time setup:
+
+```bash
+backstop reference
+```
+
+Test for changes and show a report:
+
+```bash
+backstop test
+```
 
 ## Send a pull request (PR) for the changes
 

--- a/backstop.json
+++ b/backstop.json
@@ -1,0 +1,57 @@
+{
+  "id": "default",
+  "report": ["browser"],
+
+  "paths": {
+    "bitmaps_reference": "backstop/reference",
+    "bitmaps_test": "backstop/results",
+    "ci_report": "backstop/reports/ci",
+    "engine_scripts": "backstop/scripts",
+    "html_report": "backstop/reports/html"
+  },
+
+  "asyncCaptureLimit": 4,
+  "engine": "puppeteer",
+  "mergeImgHack": true,
+
+  "viewports": [
+    { "label": "iphone5", "width": 320, "height": 568 },
+    { "label": "librebootx200", "width": 1280, "height": 800 }
+  ],
+
+  "scenarios": [
+    {
+      "label": "Home",
+      "referenceUrl": "https://seagl.org/",
+      "url": "http://localhost:4000/"
+    },
+    {
+      "label": "News",
+      "referenceUrl": "https://seagl.org/news/",
+      "url": "http://localhost:4000/news/",
+      "delay": 1000
+    },
+    {
+      "label": "CodeOfConduct",
+      "referenceUrl": "https://seagl.org/code_of_conduct.html",
+      "url": "http://localhost:4000/code_of_conduct.html"
+    },
+    {
+      "label": "GetInvolved",
+      "referenceUrl": "https://seagl.org/get_involved.html",
+      "url": "http://localhost:4000/get_involved.html"
+    },
+    {
+      "label": "Sponsors",
+      "referenceUrl": "https://seagl.org/sponsors/2019.html",
+      "url": "http://localhost:4000/sponsors/2019.html"
+    },
+    {
+      "label": "Map",
+      "referenceUrl": "https://seagl.org/maps/2019.html",
+      "url": "http://localhost:4000/maps/2019.html",
+      "readyEvent": "map loaded",
+      "delay": 2000
+    }
+  ]
+}

--- a/maps/2019.html
+++ b/maps/2019.html
@@ -79,6 +79,8 @@ body_id: maps
     zoom: 15
   });
 
+  map.on("load", () => console.log("map loaded"));
+
   map.addControl(new mapboxgl.NavigationControl({ showCompass: false }));
 
   new mapboxgl.Marker({ color: "#1d7193" })


### PR DESCRIPTION
I like to have something like this set up when working on an existing site so I can catch accidental changes.

![screenshot_2019-12-03-22-16-40](https://user-images.githubusercontent.com/1844746/70117592-b3386600-161a-11ea-870b-fb2929c512f0.gif)

This commits just the configuration so that it's easy to get started; the heavy lifting is done by an optional dependency.

Also slipping in a few edits to the readme leading up to this.