### PR TITLE
Add note about participating to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,8 +5,15 @@
   </div>
 
   <div>
-      <p>All website code is licensed {{ site.custom.license.site_code }}.</p>
-      <p>Unless otherwise specified, all website content is licensed {{ site.custom.license.content }}.</p>
+    <p>Interested in helping make SeaGL happen? Email
+    participate@seagl.org! We'd love to have anyone help out, and are
+    especially interested in folks who can help with finance and
+    fundraising, on-site logistics, promotion and outreach, and OSEM.</p>
+  </div>
+
+  <div>
+    <p>All website code is licensed {{ site.custom.license.site_code }}.</p>
+    <p>Unless otherwise specified, all website content is licensed {{ site.custom.license.content }}.</p>
   </div>
 
   <footer>


### PR DESCRIPTION

![1586788320_0732_13 04 2020](https://user-images.githubusercontent.com/5055819/79129064-6481a200-7d59-11ea-94cf-8b0b187c0d4e.png)
This adds a note to the footer about how folks who are interested in
helping organize and run SeaGL can reach us and help. We want everyone
who is interested to let us know and also want to ask for specific
skills we're looking for, so I made the call both broad and listed the
roles we need filled. This footer will be included in every SeaGL
website page.