### PR TITLE
Replace Freenode with freenode

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ custom:
         schedule:           https://osem.seagl.org/conferences/seagl2019/schedule/events
     a:
         irc:
-            network:        <a href="https://freenode.net/kb/answer/chat">Freenode</a>
+            network:        <a href="https://freenode.net/kb/answer/chat">freenode</a>
             channel:        <a href="https://webchat.freenode.net?randomnick=1&channels=%23seagl">#seagl</a>
         email:
             award:          <a href="mailto:&#097;&#119;&#097;&#114;&#100;&#064;&#115;&#101;&#097;&#103;&#108;&#046;&#111;&#114;&#103;">&#097;&#119;&#097;&#114;&#100;&#064;&#115;&#101;&#097;&#103;&#108;&#046;&#111;&#114;&#103;</a>


### PR DESCRIPTION
freenode brands itself as freenode (with a lowercase `f`). This can be seen on https://freenode.net/project.