### PR TITLE
Create initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+os: linux
+install:
+ - bundle install
+script:
+ - jekyll
+notifications:
+  email: false


### PR DESCRIPTION
This is a bit of a shot in the dark, but in my experience, setting up Travis CI initially always is.  If this fails CI, having Travis enabled will nonetheless allow iterating in a pull request until CI turns green.

Ref #74.