### PR TITLE
Update CFP update to clarify that speaker notifications will be delayed due to CFP extension

### DIFF
--- a/_posts/2020-07-14-CFP-open.md
+++ b/_posts/2020-07-14-CFP-open.md
@@ -7,7 +7,7 @@ published: true
 categories: news
 ---
 
-**UPDATE** - The CFP deadline was extended to Wednesday, September 9th. See [CFP extension](https://seagl.org/news/2020/08/20/cfp-extension.html) for complete info - **UPDATE**
+**UPDATE** - The CFP deadline was extended to Wednesday, September 9th. See [CFP extension](https://seagl.org/news/2020/08/20/cfp-extension.html) for complete info. Speaker notifications will go out by the end of September, with the schedule published shortly after. - **UPDATE**
 
 We are more than excited to invite you to speak at SeaGL 2020! The Seattle GNU/Linux Conference (SeaGL) is a grassroots technical conference dedicated to spreading awareness and knowledge about the GNU/Linux community and free / libre / open source software and hardware. This year it will be held remotely for the first time, as we all cope with the global pandemic.
 


### PR DESCRIPTION
We etended the CFP. This naturally means that we need to push back the dates we originally said we would notify speakers about talk acceptances.﻿
