### PR TITLE
Update volunteer blog post

### DIFF
--- a/_posts/2020-10-05-call-for-volunteers.md
+++ b/_posts/2020-10-05-call-for-volunteers.md
@@ -9,33 +9,25 @@ categories: news
 
 SeaGL is approaching fast, and we need your help! SeaGL is a completely volunteer run conference,
 and with our new ✨technical landscape ✨we're going to need some extra hands. Please email
-participate@seagl.org if you're interested in volunteering, shifts are minimum 1 hour for any of
-these positions:
+participate@seagl.org if you're interested in volunteering and we will send you the sign up sheet!
+Here's what we need help with:
 
 ### Help Desk
-Be online on either video or chat to answer questions
-
-- Dedicated help desk video channel - one position will primarily be answering questions in video, answering in chat if video is quiet
-- Dedicated help desk chat channel - one position will be primarily answering questions on chat, answering on video if chat is quiet
-- Answer questions about registration, recording, talk tracks, etc. We will provide FAQ fact sheet that will hopefully answer most questions, and give you direct contact info for Lucy and other staff for other questions
+Be in our Help Desk IRC channel to answer common questions about registration, recording, talk
+tracks, etc. We will provide FAQ fact sheet that will hopefully answer most questions, and give you
+direct contact info for SeaGL staff in case a question comes up you can't answer.
 
 ### Talk Emcee
 Host the talk!
 
+- Be in a dedicated video call with the speaker
+- Be in the talk 10 minutes before it starts to chat with the speaker, get name pronunciation + preferences, etc.
 - Introduce the speaker if they'd like
 - Give speaker time cues if they'd like
-- Moderate questions (ask any typed in chat, "call" on people)
-- Be in the talk 10 minutes before it starts to chat with the speaker, get name pronunciation + preferences, etc.
-- Enforce Code of Conduct and time restraints
-
-### Talk Technician
-Ensure the talk goes smoothly
-
-- Enforce Code of Conduct and time restraints
-- Share pre-recorded talk
-- Be technical support for the talk - we will have a technical training 2 weeks before the
-  conference, and any more serious issues can be escalated to SeaGL staff.
-- Get help from SeaGL staff if needed
+- Questions will be asked in the track IRC channel. Ask questions aloud to speaker on video call
+  during Q&A.
+- Enforce Code of Conduct in IRC channel
+- Escalate to SeaGL staff if needed
 
 All volunteers will be trained on the Code of Conduct and on their roles 2 weeks before the
 conference - if you'd like to volunteer, we will do everything we can to ensure you feel prepared


### PR DESCRIPTION
This updates the volunteers blog post to account for the new tech stack
and speaker-flow. Because we won't have participants on video a video
help-desk is no longer necessary. We will also have SeaGL staff managing
the technical side of the videos and IRC channels, so a per-talk IRC
channel isn't necessary. This updates the blog post to remove the
unnecessary positions, and updates descriptions.