### PR TITLE
Change chat links from Freenode to Libera.Chat

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,8 +45,8 @@ custom:
         site_code:          <a href="https://github.com/SeaGL/seagl.github.io/blob/master/LICENSE">GPL v3.0</a>
     url:
         irc:
-            network:        https://freenode.net/kb/answer/chat
-            webchat:        https://webchat.freenode.net?randomnick=1&channels=%23seagl
+            network:        https://libera.chat/
+            webchat:        https://web.libera.chat/#SeaGL
             matrix:         https://matrix.to/#/#SeaGL:matrix.org
         mailing_list:
             seagl_announce: https://groups.google.com/forum/#!forum/seagl_announce
@@ -58,8 +58,8 @@ custom:
         schedule:           https://osem.seagl.org/conferences/seagl2020/schedule/events
     a:
         irc:
-            network:        <a href="https://freenode.net/kb/answer/chat">freenode</a>
-            webchat:        <a href="https://webchat.freenode.net?randomnick=1&channels=%23seagl">#seagl</a>
+            network:        <a href="https://libera.chat/">Libera.Chat</a>
+            webchat:        <a href="https://web.libera.chat/#SeaGL">#SeaGL</a>
             matrix:         <a href="https://matrix.to/#/#SeaGL:matrix.org">Matrix</a>
         email:
             award:          <a href="mailto:&#097;&#119;&#097;&#114;&#100;&#064;&#115;&#101;&#097;&#103;&#108;&#046;&#111;&#114;&#103;">&#097;&#119;&#097;&#114;&#100;&#064;&#115;&#101;&#097;&#103;&#108;&#046;&#111;&#114;&#103;</a>


### PR DESCRIPTION
Re SeaGL/organization#125. Implementation notes:

- Preserving Freenode links in old blog posts
- Webchat pending https://github.com/Libera-Chat/libera-chat.github.io/issues/19