### PR TITLE
Fail the build on undefined variables 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,10 @@ future:         false # Workaround for SeaGL/seagl.github.io#170
 timezone:       America/Los_Angeles
 markdown:       kramdown
 highlighter:    rouge
+liquid:
+  error_mode: strict
+  strict_filters: true
+  strict_variables: true
 
 # Allowed plugins: https://pages.github.com/versions/
 plugins: &plugins

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,6 @@
+{% comment %} Workaround for https://github.com/Shopify/liquid/issues/1034 {% endcomment %}
+{% assign nav = nil %}{% if page contains "nav" %}{% assign nav = page.nav %}{% endif %}
+
 <nav class="navbar navbar-default" role="navigation" id="main-nav">
   <!-- Brand and toggle get grouped for better mobile display -->
   <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".top-nav-collapse">
@@ -13,14 +16,14 @@
 
   <div id="main-nav-container" class="collapse navbar-collapse top-nav-collapse">
     <ul class="nav pull-left navbar-nav main-nav-links inline-list">
-      <li {% if page.nav == "home" %} class="active" | {% endif %} ><a href="/">Home</a></li>
+      <li {% if nav == "home" %} class="active" | {% endif %} ><a href="/">Home</a></li>
       <li><a href="{{ site.custom.url.schedule }}">2020 Program</a></li>
-      <!-- <li {% if page.nav == "schedule" %} class="active" | {% endif %} ><a href="/schedule/{{ site.custom.year }}.html">Schedule</a></li> -->
+      <!-- <li {% if nav == "schedule" %} class="active" | {% endif %} ><a href="/schedule/{{ site.custom.year }}.html">Schedule</a></li> -->
     </ul>
 
     <ul class="nav pull-right navbar-nav main-nav-links inline-list">
-      <li {% if page.nav == "get_involved" %} class="active" | {% endif %} ><a href="/get_involved.html">Get Involved</a></li>
-      <li {% if page.nav == "sponsors" %} class="active" | {% endif %} ><a href="/sponsors/">Sponsors</a></li>
+      <li {% if nav == "get_involved" %} class="active" | {% endif %} ><a href="/get_involved.html">Get Involved</a></li>
+      <li {% if nav == "sponsors" %} class="active" | {% endif %} ><a href="/sponsors/">Sponsors</a></li>
     </ul>
   </div><!-- /.navbar-collapse -->
 </nav>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -5,7 +5,7 @@
     <meta charset='utf-8' />
     <meta http-equiv="X-UA-Compatible" content="chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {% if page.description %}<meta name="description" content="{{ page.description }}" />{% endif %}
+    {% if page contains "description" %}<meta name="description" content="{{ page.description }}" />{% endif %}
 
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} RSS" href="{{ site.origin }}/feed.xml" />
     <link rel="image_src" href="{{ site.origin }}/img/logo.png" />
@@ -28,13 +28,13 @@
     <link rel="stylesheet" type="text/css" media="screen" href="/css/app/code_of_conduct.css">
     <link rel="stylesheet" type="text/css" media="screen" href="/css/app/ribbon.css">
 
-    <title>{% if page.title %}{{ page.title }} | {% endif %}Seattle GNU/Linux Conference</title>
+    <title>{{ page.title }}{% unless page.title contains site.name %} | {{ site.name }}{% endunless %}</title>
 
     <script src="/js/jquery.min.js"></script>
     <script src="/js/bootstrap3.min.js"></script>
   </head>
 
-  <body id="{{ page.body_id }}">
+  <body id="{% if page contains "body_id" %}{{ page.body_id }}{% endif %}">
     {{ content }}
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,13 +14,13 @@ layout: page
 
       <div class="row">
         <div class="col-md-6">
-          {% if page.previous.url %}
+          {% if page.previous %}
             <a class="prev" href="{{page.previous.url}}">&laquo; {{page.previous.title}}</a>
           {% endif %}
         </div>
 
         <div class="col-md-6 text-right">
-          {% if page.next.url %}
+          {% if page.next %}
             <a class="next" href="{{page.next.url}}">{{page.next.title}} &raquo;</a>
           {% endif %}
         </div>

--- a/_posts/2014-06-20-CFP-Open.md
+++ b/_posts/2014-06-20-CFP-Open.md
@@ -9,7 +9,7 @@ categories: news
 
 Our Call for Participation is Open!
 
-[Submit your presentation]({{ site.custom.url.survey.cpf }})
+[Submit your presentation](http://survey.seagl.org/index.php/935137/lang-en)
 now.
 
 The Seattle GNU/Linux Conference is now seeking presenters. We want to present a

--- a/_posts/2014-07-29-CFP-Extension.md
+++ b/_posts/2014-07-29-CFP-Extension.md
@@ -11,7 +11,7 @@ Our Call for Participation has been extended to August 3rd!
 
 If you have been on the fence about participating, or thought you had missed
 the early deadine, fear not, for we have decided to give everybody an extra bit
-of time to [get their awesome submissions in]({{ site.custom.url.survey.cpf }})!
+of time to [get their awesome submissions in](http://survey.seagl.org/index.php/935137/lang-en)!
 
 <strong>The NEW CFP deadline is midnight on August 3rd (PDT).</strong> We look
 forward to seeing you this fall in Seattle!

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: page
 nav: home
 body_id: home
+title: Seattle GNU/Linux Conference
 description: SeaGL is a grassroots technical conference dedicated to spreading awareness and knowledge about the GNU/Linux community and free/libre/open-source software/hardware.
 ---
 


### PR DESCRIPTION
Currently if you mistype a variable name or [delete a variable that’s still in use][delete] Jekyll will silently ignore the error. Want to enable its [strict mode][strict] to fail the build instead?

Due to Shopify/liquid#1034 working with deliberately undefined variables is a pain but I’d prefer to make the tradeoff.

[delete]: https://github.com/SeaGL/seagl.github.io/commit/58456594b5853c0c08a996e014b70f209cf48798#diff-ecec67b0e1d7e17a83587c6d27b6baaaa133f42482b07bd3685c77f34b62d883L32-L34
[strict]: https://github.com/jekyll/jekyll/blob/76517175e700d80706c9139989053f1c53d9b956/docs/_docs/configuration/liquid.md