### PR TITLE
Create Code of Practice Page

### DIFF
--- a/code_of_practice.html
+++ b/code_of_practice.html
@@ -1,0 +1,62 @@
+---
+layout: page
+title: Program Committee Code of Practice
+description: Code of Practice
+nav: code_of_practice
+body_id: cop
+redirect_from:
+  - /cop
+  - /CoP
+---
+
+<div class="col-md-12">
+    <h1>Program Committee Code of Practice</h1>
+    <div class="row">
+      <div class="col-md-12">
+        <p>
+          This is what we believe in and how we operate as we go about our business of building the best possible program and schedule for <a href="https://seagl.org">SeaGL</a>.
+        </p>
+        <p>
+          As members of the SeaGL program committee and proposal reviewers,
+          aside from the <a href="https://seagl.org/code_of_conduct.html">SeaGL Code of Conduct</a>,
+          we also agree to operate according to these values and statements:
+        </p>
+        <h2>Values</h2>
+        <ul>
+          <li>We believe in the importance and power of free and open source software.</li>
+          <li>We believe in putting the needs of our audience and our community before our needs or those of our employers.</li>
+          <li>We believe in boosting the voices of others above our own.</li>
+          <li>We believe in mentoring and helping to create the speakers, leaders, and contributors of the future.</li>
+          <li>We believe in supporting diversity in thoughts and experiences in the talks and speakers we select for SeaGL.</li>
+          <li>We believe in creating and protecting a SeaGL environment that welcomes all people in safety and comfort.</li>
+        </ul>
+        <h2>How Do We Operate?</h2>
+        <p>
+          How are these values reflected in how we operate as program committee members and reviewers?
+          There could be many different ways, obviously, but here are some examples of what we will do our best to do:
+        </p>
+        <ul>
+          <li>Promote the CFP to members of the communities we participate in</li>
+          <li>Seek out unreached/underrepresented/underserved communities and advocate for them and their talks</li>
+          <li>Provide opportunities for new/less-experienced speakers to present talks and keynotes</li>
+          <li>As time allows, assist people with their proposals and accepted talks, to improve their quality and better adapt them for our unique event</li>
+          <li>Attempt to do all initial reviews without knowing who submitted them, within the constraints of the system</li>
+          <li>Only vote on talks we feel qualified to review</li>
+          <li>Abstain from voting on talks where we made substantial contributions to the the proposal (but we can advocate during the review call)</li>
+          <li>As much as possible, don't allow our personal or professional biases (or those of our employer) to influence our talk reviews</li>
+        </ul>
+        <p>
+          We are all pleased to have the opportunity to serve the SeaGL community and share this Code of Practice with you.
+          If you are interested in getting involved with organizing or volunteering, please contact {{ site.custom.a.email.participate }}.
+          Otherwise, we hope to see you at SeaGL this year!
+        </p>
+        <p>
+          All content published on the SeaGL website is licensed <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA</a>>.
+          You are encouraged to copy, modify, and redistribute this Code of Practice however you and your event need.
+        </p>
+        <p>
+          <i>Last Updated: June 22, 2021</i>
+        </p>
+      </div><!--/span12-->
+    </div><!--/row-->
+  </div><!--/span12-->

--- a/css/app/code_of_practice.css
+++ b/css/app/code_of_practice.css
@@ -1,0 +1,3 @@
+#cop #policy-content {
+  display: none;
+}


### PR DESCRIPTION
This year, we are creating a static Code of Practice page on the site
rather than a blog post. The Code of Practice doesn't really change from
year to year. Instead, we re-affirm our commitment to abide by it. By
having it as a static page, it will be easier to re-use, link to, and
reference.