### PR TITLE
Use CFP announcement post as a landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ custom:
         location:           https://seattlecentral.edu
         prospectus:         /sponsors/SeaGL_Exhibitor_Sponsor_Prospectus_2021.pdf
         register:           https://osem.seagl.org/conferences/seagl2021/register/new
-        cfp:                https://osem.seagl.org/conferences/seagl2021
+        cfp:                /news/2021/06/24/cfp
         schedule:           https://osem.seagl.org/conferences/seagl2021/schedule/events
     a:
         irc:

--- a/_posts/2021-06-24-cfp.md
+++ b/_posts/2021-06-24-cfp.md
@@ -5,6 +5,8 @@ status: publish
 type: post
 published: true
 categories: news
+redirect_from:
+  - /cfp
 ---
 
 Welcome to the 2021 SeaGL Call For Proposals!  Every year, we want to hear from YOU, and we're always looking for speakers who are traditionally underrepresented in tech, and people with perspectives uncommonly heard, as well as first-time speakers.  Because we're virtual for the second year in a row, there is opportunity for speakers anywhere in the world to submit talks!  In 2020, we had talks from four continents!!  So let's take advantage of our virtual closeness for another year.
@@ -22,7 +24,7 @@ Program Published: Late September 2021
 
 CONFERENCE: Friday 5 November and Saturday 6 November 2021!
 
-Submit at: [OSEM](https://osem.seagl.org)
+Submit at: [OSEM][submit]
 
 ### Committee and Code of Practice
 The Program Committee is the group responsible for choosing and scheduling all of the great talks you enjoy at SeaGL. This year the committee steering the Program consists of:
@@ -79,7 +81,7 @@ We do not have longer time slots available at SeaGL 2021 because the online medi
 SeaGL pioneered the idea of CfP Office Hours, so stay tuned for details, and if you need help in the meantime, please email us at {{ site.custom.a.email.cfp-help }}, and we'd love to help you work through a good proposal.
 
 ### How To Submit
-FINALLY, let's talk about how to submit!  First, you'll go to SeaGL's [OSEM](https://osem.seagl.org) and either create an account or log in to an account you have previously used.  For those of you who have submitted before, this is the same system as the last several years.
+FINALLY, let's talk about how to submit!  First, you'll go to SeaGL's [OSEM][submit] and either create an account or log in to an account you have previously used.  For those of you who have submitted before, this is the same system as the last several years.
 
 Scroll down to the Call For Papers section, and "Submit your paper now" for your proposal, and then New Proposal.  There you'll input the Title, Talk Type (there is only one - 20m talk), and the Abstract, up to 500 words.  Do not put your name or biography in your proposal.  Repeated, **do not put your name or your bio in your proposal**.  It is part of our [Code of Practice](https://seagl.org/code_of_practice.html) that our initial review is unaware of who the submitter is, therefore **any proposal which includes biographical information will be rejected**.  Your bio will be asked for later.
 
@@ -88,4 +90,7 @@ When you have submitted, you will be taken to a page called Proposals for SeaGL 
 Finally, please find the plaintext link to our submission software here: https://osem.seagl.org/conferences/seagl2021
 
 ### Thank you!
-Thank you!!  Please email us or [tweet](https://twitter.com/seagl) at us with any questions!  And don't forget to [Submit Early, Submit Often](https://osem.seagl.org)!
+Thank you!!  Please email us or [tweet](https://twitter.com/seagl) at us with any questions!  And don't forget to [Submit Early, Submit Often][submit]!
+
+
+[submit]: https://osem.seagl.org/conferences/seagl2021#callforpapers


### PR DESCRIPTION
OSEM currently makes for a terrible landing page. Want to use the CFP announcement post for that instead?

- [main navigation](https://github.com/SeaGL/seagl.github.io/commit/dcc54177a2851f1612be38e18738de73f1556f6a) → announcement
- [seagl.org/cfp](https://seagl.org/) → announcement
- announcement → OSEM