### PR TITLE
Customized webchat

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,7 +46,7 @@ custom:
     url:
         irc:
             network:        https://libera.chat/
-            webchat:        https://web.libera.chat/#SeaGL
+            webchat:        https://chat.seagl.org/
         mailing_list:
             seagl_announce: https://groups.google.com/forum/#!forum/seagl_announce
             seagl_organize: https://groups.google.com/forum/#!forum/seagl_organize
@@ -58,7 +58,7 @@ custom:
     a:
         irc:
             network:        <a href="https://libera.chat/">Libera.Chat</a>
-            channel:        <a href="https://web.libera.chat/#SeaGL">#SeaGL</a>
+            channel:        <a href="https://chat.seagl.org/">#SeaGL</a>
         matrix:
             network:        <a href="https://matrix.org/">Matrix</a>
             room:           <a href="https://matrix.to/#/#SeaGL:seattlematrix.org">#SeaGL:seattlematrix.org</a>

--- a/chat.html
+++ b/chat.html
@@ -1,0 +1,3 @@
+---
+redirect_to: https://chat.seagl.org/
+---


### PR DESCRIPTION
Re [last meeting](https://github.com/SeaGL/organization/blob/master/meetings/2021/20210712-allhands.md#getting-staff-into-matrix-rooms-salt) and some clarification from @altsalt, I’ve customized Kiwi IRC over at [SeaGL/chat.seagl.org](https://github.com/SeaGL/chat.seagl.org) similar to what we had for the virtual conference, but simpler for the sake of maintainability—no Jitsi integration, no embedded videos, no suggested channels, and none of the UI customizations that required a fork.

Please have a look and let me know what else would be helpful.