### PR TITLE
Extend the CfP by two weeks

### DIFF
--- a/_posts/2021-06-24-cfp.md
+++ b/_posts/2021-06-24-cfp.md
@@ -14,7 +14,7 @@ Welcome to the 2021 SeaGL Call For Proposals!  Every year, we want to hear from 
 ### Details
 CfP Open: Thursday 24 June 2021
 
-CfP Close: Thursday 5 August 2021
+CfP Close: ~~Thursday 5 August 2021~~Thursday 19 August 2021
 
 Acceptances: Early September 2021
 

--- a/_posts/2021-08-05-cfp_extended.md
+++ b/_posts/2021-08-05-cfp_extended.md
@@ -14,7 +14,7 @@ This gives you two more weeks to submit a talk proposal about free software, sec
 If you need some ideas, check out our [suggested topic categories](https://seagl.org/news/2021/06/24/cfp.html#talk-topicslabels).
 
 If you have questions about the [Call for Proposals](https://seagl.org/news/2021/06/24/cfp) process or want feedback on your talk proposal, we have one more [office hours](https://seagl.org/news/2021/07/30/office_hours.html) session.
-Join us in chat at [chat.seagl.org](https://chat.seagl.org/) or [on video](https://meet.seattlematrix.org/SeaGLCFPHelp) at 3:00 PM Pacific on Saturday, August 7.
+Join us in chat or on video at [chat.seagl.org](https://chat.seagl.org/) at 3:00 PM Pacific on Saturday, August 7.
 If you can't make the office hours, email your questions to [cfp-help@seagl.org](mailto:cfp-help@seagl.org) any time.
 
 When you're ready to submit, our [CfP portal](https://osem.seagl.org/conferences/seagl2021#callforpapers) is ready for you!

--- a/_posts/2021-08-05-cfp_extended.md
+++ b/_posts/2021-08-05-cfp_extended.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: 'SeaGL 2021 CfP extended'
+status: publish
+type: post
+published: true
+categories: news
+---
+
+Need a little more time to get your proposal together for SeaGL 2021?
+Good news!
+We've *extended the submission deadline to August 19*.
+This gives you two more weeks to submit a talk proposal about free software, security, tech culture, community, and more!
+If you need some ideas, check out our [suggested topic categories](https://seagl.org/news/2021/06/24/cfp.html#talk-topicslabels).
+
+If you have questions about the [Call for Proposals](https://seagl.org/news/2021/06/24/cfp) process or want feedback on your talk proposal, we have one more [office hours](https://seagl.org/news/2021/07/30/office_hours.html) session.
+Join us in chat at [chat.seagl.org](https://chat.seagl.org/) or [on video](https://meet.seattlematrix.org/SeaGLCFPHelp) at 3:00 PM Pacific on Saturday, August 7.
+If you can't make the office hours, email your questions to [cfp-help@seagl.org](mailto:cfp-help@seagl.org) any time.
+
+When you're ready to submit, our [CfP portal](https://osem.seagl.org/conferences/seagl2021#callforpapers) is ready for you!


### PR DESCRIPTION
Post for CfP extension discussed via email. Adds a new post and updates the CfP post with the new deadline.