### PR TITLE
Add Lightning Talks Blog Post

### DIFF
--- a/_posts/2021-08-18-Lightning-Talks.md
+++ b/_posts/2021-08-18-Lightning-Talks.md
@@ -19,6 +19,6 @@ A few examples are:
 * Tech examples: Event organization, coding, design, documentation, open source, etc. 
 * Non-tech examples: non-profit work, hobbies/programs (eg. community gardens), sports teams, theater, etc.
 
-Our one ask is that there are no promotions of any kind - meaning, please no video resumes, no company/product promos, etc. 
+Our one request is that there are no promotions of any kind - meaning, please no video resumes, no company/product promos, etc. 
 
 We’re looking forward to hearing from you, our community. Please [submit your talk ideas](https://forms.gle/3iVpzavUxmjLTXmm8) **before September 8, 2021**.

--- a/_posts/2021-08-18-Lightning-Talks.md
+++ b/_posts/2021-08-18-Lightning-Talks.md
@@ -7,9 +7,9 @@ published: true
 categories: news
 ---
 
-This year we’re incredibly excited to announce that we’re hosting lightning talks at SeaGL!
-Think of this space as a great opportunity to learn about fun topics,
-or even present your own talk (maybe even for the first time!). 
+We’re incredibly excited to announce that we’re hosting lightning talks at SeaGL this year!
+Think of this space as a great opportunity to learn about fun topics, or even present your own talk.
+It's a great way to get comfortable with speaking to an audience or to explore the kernel of an idea that could become a full-length talk at SeaGL 2022!
 
 The lightning talks will be a series of 5 minute talks which will be pre-recorded - meaning
 that we can accommodate speakers from all over the world!

--- a/_posts/2021-08-18-Lightning-Talks.md
+++ b/_posts/2021-08-18-Lightning-Talks.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: 'Lightning Talks at SeaGL!'
+title: 'Lightning Talks at SeaGL 2021!'
 status: publish
 type: post
 published: true

--- a/_posts/2021-08-18-Lightning-Talks.md
+++ b/_posts/2021-08-18-Lightning-Talks.md
@@ -21,4 +21,4 @@ A few examples are:
 
 Our one ask is that there are no promotions of any kind - meaning, please no video resumes, no company/product promos, etc. 
 
-We’re looking forward to hearing from you, our community. Please submit your talk ideas [here](https://forms.gle/3iVpzavUxmjLTXmm8) **before September 8, 2021**.
+We’re looking forward to hearing from you, our community. Please [submit your talk ideas](https://forms.gle/3iVpzavUxmjLTXmm8) **before September 8, 2021**.

--- a/_posts/2021-08-18-Lightning-Talks.md
+++ b/_posts/2021-08-18-Lightning-Talks.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: 'Lightning Talks at SeaGL!'
+status: publish
+type: post
+published: true
+categories: news
+---
+
+This year we’re incredibly excited to announce that we’re hosting lightning talks at SeaGL!
+Think of this space as a great opportunity to learn about fun topics,
+or even present your own talk (maybe even for the first time!). 
+
+The lightning talks will be a series of 5 minute talks which will be pre-recorded - meaning
+that we can accommodate speakers from all over the world!
+We’re looking for any community focused talks.
+A few examples are:
+
+* Tech examples: Event organization, coding, design, documentation, open source, etc. 
+* Non-tech examples: non-profit work, hobbies/programs (eg. community gardens), sports teams, theater, etc.
+
+Our one ask is that there are no promotions of any kind - meaning, please no video resumes, no company/product promos, etc. 
+
+We’re looking forward to hearing from you, our community. Please submit your talk ideas [here](https://forms.gle/3iVpzavUxmjLTXmm8) **before September 8, 2021**.


### PR DESCRIPTION
This change adds a new blog post announcing our Lightning Talks. The post content was prepared by @sramkrishna and @alisonjudy