### PR TITLE
Re: Making the announce mailing list more prominent

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<div class="container">
+<footer class="container">
   <div class="well well-mascot">
     <p>SeaGL is dedicated to a harassment-free conference experience for everyone.</p>
     <p>Our code of conduct can be found <a href="/code_of_conduct.html">here</a></p>
@@ -17,14 +17,12 @@
     <p>All website code is licensed {{ site.custom.license.site_code }}. Unless otherwise specified, all website content is licensed {{ site.custom.license.content }}.</p>
   </div>
 
-  <footer>
-    <ul id="footer-nav" role="navigation" class="list-inline">
-      <li>{{ site.custom.a.social.github }}</li>
-      <li>{{ site.custom.a.social.mastodon }}</li>
-      <li>{{ site.custom.a.social.pixelfed }}</li>
-      <li>{{ site.custom.a.social.twitter }}</li>
-      <li>{{ site.custom.a.social.facebook }}</li>
-      <li>{{ site.custom.a.social.youtube }}</li>
-    </ul>
-  </footer>
-</div>
+  <ul id="footer-nav" role="navigation" class="list-inline">
+    <li>{{ site.custom.a.social.github }}</li>
+    <li>{{ site.custom.a.social.mastodon }}</li>
+    <li>{{ site.custom.a.social.pixelfed }}</li>
+    <li>{{ site.custom.a.social.twitter }}</li>
+    <li>{{ site.custom.a.social.facebook }}</li>
+    <li>{{ site.custom.a.social.youtube }}</li>
+  </ul>
+</footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,6 +7,11 @@
   <div>
     <p>Please <a href="/feedback">let us know</a> if you have any feedback about SeaGL. You're welcome to submit anonymously.</p>
 
+    <p>
+      Stay informed by signing up for our low-traffic
+      {{ site.custom.a.mailing_list.seagl_announce }}.
+    </p>
+
     <p>Interested in helping make SeaGL happen? Email
     participate@seagl.org! We'd love to have anyone help out, and are
     especially interested in folks who can help with finance and

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
     <p>All website code is licensed {{ site.custom.license.site_code }}. Unless otherwise specified, all website content is licensed {{ site.custom.license.content }}.</p>
   </div>
 
-  <ul id="footer-nav" role="navigation" class="list-inline">
+  <ul id="footer-nav" role="navigation" class="list-inline-delimited">
     <li>{{ site.custom.a.social.github }}</li>
     <li>{{ site.custom.a.social.mastodon }}</li>
     <li>{{ site.custom.a.social.pixelfed }}</li>

--- a/_welcome.md
+++ b/_welcome.md
@@ -31,3 +31,9 @@ we promise to protect your data.
 -->
 
 [online]: /news/2021/06/08/format-2021
+
+### Stay informed
+
+Sign up for our low-traffic
+[announcement mailing list]({{ site.custom.url.mailing_list.seagl_announce }})
+or subscribe to our [RSS news feed](/feed.xml).

--- a/css/app/seagl.scss
+++ b/css/app/seagl.scss
@@ -250,7 +250,8 @@ ol > li > ol {
   background-color: #0C5A73;
 }
 #footer-nav {
-  margin: 6em auto 4em auto;
+  margin-bottom: 4em;
+  margin-top: 2em;
 }
 .venue-map {
   height: 66vh;

--- a/css/app/seagl.scss
+++ b/css/app/seagl.scss
@@ -65,6 +65,18 @@ samp {
 ol > li > ol {
   list-style-type: lower-alpha;
 }
+.list-inline-delimited {
+  display: flex;
+  flex-flow: row wrap;
+  list-style: none;
+  padding-left: 0;
+
+  & > li:not(:last-child)::after {
+    content: "·";
+    margin-left: 1ch;
+    margin-right: 1ch;
+  }
+}
 .sidebar-nav {
   padding: 9px 0;
 }


### PR DESCRIPTION
Re @funnelfiasco’s suggestions:

> 1. Add an "Announcements" section to the sidebar that says "Sign up for our low-traffic \[announcement mailing list\](URL goes here) to stay informed."
>
> 2. Adding the same to the footer so it appears on all of the blog posts, etc

Sounds good to me. Here’s something along those lines.

I mentioned the RSS feed as well—

> <img alt="screenshot" src="https://user-images.githubusercontent.com/1844746/130278872-4e58557b-965e-4f79-8e43-8670a601f8c6.png" width="390" />

—and just removed the long list of social media links entirely:

> <img alt="screenshot" src="https://user-images.githubusercontent.com/1844746/130278881-df9315c6-4a59-4d28-8b63-76533de264af.png" width="504" />

I’m not very confident about that decision; maybe it should still have Mastodon?