### PR TITLE
Added a redirect url for the sticker pack blog post

### DIFF
--- a/_posts/2021-11-03-seagl-stickers.md
+++ b/_posts/2021-11-03-seagl-stickers.md
@@ -6,6 +6,8 @@ type: post
 published: true
 categories: news
 tags: '2021'
+redirect_from:
+  - /stickers
 ---
 
 Have you always wanted to channel your inner Patch the SeaGL seagull but you didn't know how?


### PR DESCRIPTION
As we need a smaller url of the sticker pack blog post for the interstitials, I added the `/stickers`