### PR TITLE
Update social events blog post

### DIFF
--- a/_posts/2021-10-28-seagl-2021-social.md
+++ b/_posts/2021-10-28-seagl-2021-social.md
@@ -6,6 +6,8 @@ type: post
 published: true
 categories: news
 tags: '2021'
+redirect_from:
+ - /social_events
 ---
 
 Part of what makes SeaGL so special are the social events.
@@ -15,21 +17,28 @@ Thanks so much to everyone who's helping us bring the fun!
 
 All times below are in [Pacific Daylight Time](https://time.is/compare/0800AM_5_Nov_2021_in_Seattle)
 
-### Friday, November 5
+### Schedule
+
+**Friday, November 5**
 
 * [**2:45–3:15 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/867) Booth Crawl — Meet our lovely vendors and community groups!
 * [**4:30–5:30 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/872) [DevOps Party Games at SeaGL!](https://devopspartygames.com/)
 * [**5:45–7:30 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/873) Cocktails and Mocktails with Mako — back by popular demand!
 
-### Saturday, November 6
+**Saturday, November 6**
 
-* [**9:15–9:30 AM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/874) Costume Contest — Get there early to strut your stuff! We have prizes for Most Creative, Most Nerdy, and Audience Choice. Voting will be open from 10:00 AM to 2:00 PM [via this form](https://forms.gle/PP4RN9FwT5dQmwc39). Winners will be announced at 2:30 PM, right before TeaGL. 
+* [**9:15–9:30 AM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/874) Costume Contest — Get there early to strug your stuff! We have prizes for Most Creative, Most Nerdy, and Audience Choice. Voting will be open from 10:00 AM to 2:00 PM [via this form](https://forms.gle/PP4RN9FwT5dQmwc39).
+* [**2:30–2:45 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/875) Costume Contest Winners announced! 
 * [**2:45–3:15 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/870) TeaGL — Enjoy some tea drinking and tea talk and meet your swap buddy if you participated in this year's swap. Fancy hats are always optional, and always welcome.
 * [**5:30–6:30 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/877) Tea Sandwiches with Molly and Sri — Two different sandwiches with some options for folks following along at home.
 * [**6:45–8:00 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/878) SeaGL Trivia returns with hosts Remy DeCausemaker and Elana Hashman
 
+### Attend
+
+All events will happen on the [Social Room](https://meet.seattlematrix.org/SeaGL2021_Social), except for the DevOps Party Games, which will take place on [Twitch](https://www.twitch.tv/devopspartygames). Please take a minute to sign up! 
+
 No registration is required for any of these events although you may want to check in on ingredients lists next week.
-The food and beverage programming doesn't require you to have everything to follow along, but it is a little more fun that way. 
+The food and beverage programming doesn't require you to have everything to follow along, but it is a little more fun that way.
 
 Lastly, our [Code of Conduct](https://seagl.org/code_of_conduct) applies to the social events.
 We expect folks to behave respectfully (but not seriously!) during our social events so that everyone can enjoy themselves.

--- a/_posts/2021-10-28-seagl-2021-social.md
+++ b/_posts/2021-10-28-seagl-2021-social.md
@@ -19,13 +19,13 @@ All times below are in [Pacific Daylight Time](https://time.is/compare/0800AM_5_
 
 ### Schedule
 
-**Friday, November 5**
+#### Friday, November 5
 
 * [**2:45–3:15 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/867) Booth Crawl — Meet our lovely vendors and community groups!
 * [**4:30–5:30 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/872) [DevOps Party Games at SeaGL!](https://devopspartygames.com/)
 * [**5:45–7:30 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/873) Cocktails and Mocktails with Mako — back by popular demand!
 
-**Saturday, November 6**
+#### Saturday, November 6
 
 * [**9:15–9:30 AM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/874) Costume Contest — Get there early to strug your stuff! We have prizes for Most Creative, Most Nerdy, and Audience Choice. Voting will be open from 10:00 AM to 2:00 PM [via this form](https://forms.gle/PP4RN9FwT5dQmwc39).
 * [**2:30–2:45 PM**](https://osem.seagl.org/conferences/seagl2021/program/proposals/875) Costume Contest Winners announced! 


### PR DESCRIPTION
- /social_events now redirects to the blog post, for use in the interstitials (temporary, just for conference use)
- Added links to the social room and DevOps Party Games Twitch