### PR TITLE
Update 2022 CFP Talk Topics to match OSEM

### DIFF
--- a/_posts/2022-07-06-CFP-Live.md
+++ b/_posts/2022-07-06-CFP-Live.md
@@ -47,7 +47,8 @@ These are more than words, they are a framework that we have used and will use i
 We encourage almost any topic related to open source that you have a personal engagement with. We have created a list of topic ideas you might choose to use — these might give you some ideas.
 
 - Security & Privacy: Security Practices (Personal and Industry) and Security Career, owning and controlling your [own] data
-- Hardware: Free and Open hardware projectsTools: Command line, databases, web tools, accessibility, open graphics tooling, and more
+- Hardware: Free and Open hardware projects
+- Tools: Command line, databases, web tools, accessibility, open graphics tooling, and more
 - Tech Culture: FLOSS for EveryOne: how can FLOSS be of help to those outside our immediate community?
 - Community: Community building, labor rights, & advocacy
 - DevOps: Open source DevOps, containers, continuous integration/continuous deployment, & monitoring

--- a/_posts/2022-07-06-CFP-Live.md
+++ b/_posts/2022-07-06-CFP-Live.md
@@ -46,17 +46,13 @@ These are more than words, they are a framework that we have used and will use i
 ### Talk Topics/Labels
 We encourage almost any topic related to open source that you have a personal engagement with. We have created a list of topic ideas you might choose to use — these might give you some ideas.
 
-- Security: Security Practices (Personal and Industry) and Security Career
-- Hardware: Free and Open hardware projects
-- Leaving the Walled Garden: Owning Your Own Data
-- Tools: Command line, databases, web tools, accessibility, open graphics tooling, and more
+- Security & Privacy: Security Practices (Personal and Industry) and Security Career, owning and controlling your [own] data
+- Hardware: Free and Open hardware projectsTools: Command line, databases, web tools, accessibility, open graphics tooling, and more
 - Tech Culture: FLOSS for EveryOne: how can FLOSS be of help to those outside our immediate community?
 - Community: Community building, labor rights, & advocacy
-- Virtual meetings & "meatspace"
 - DevOps: Open source DevOps, containers, continuous integration/continuous deployment, & monitoring
 - Licensing & Legal
-- Career Development in FLOSS software and hardware
-- Performance Art!  Seriously :)
+- Performance Art!
 - Misc: Have a great talk that doesn't fit these categories? Submit it!
 
 ### Talk categories and "vibe"


### PR DESCRIPTION
This change updates the 2022 CFP Post so that the talk topics match OSEM.