### PR TITLE
Announce CFP Extension

### DIFF
--- a/_posts/2022-07-06-CFP-Live.md
+++ b/_posts/2022-07-06-CFP-Live.md
@@ -15,7 +15,7 @@ Welcome to the 2022 SeaGL Call For Proposals!  Every year, we want to hear from 
 ### Details
 CfP Open: Wednesday 6 July, 2022
 
-CfP Close: Wednesday 3 August, 2022
+CfP Close: ~~Wednesday 3 August, 2022~~ Friday 19 August, 2022
 
 Acceptances: Early September 2022
 

--- a/_posts/2022-08-04-CFP-Extended.md
+++ b/_posts/2022-08-04-CFP-Extended.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: 'SeaGL 2022 Call For Proposals Extended'
+status: publish
+type: post
+published: true
+categories: news
+tags: '2022'
+---
+
+Did you perhaps forget to submit your [talk proposal](https://seagl.org/news/2022/07/06/CFP-Live.html) before the deadline?
+Wish you had a little extra time to put the finishing touch on your abstract or to submit a second (or third) propsoal?
+In that case, we've got good news for you. We have decided to extend the CFP deadline two weeks until Friday, August 19.
+We will also be continuing to hold [CFP Office Hours](https://seagl.org/news/2022/07/22/office-hours.html) during this extension.
+So be sure to take advantage of this extension and not delay, get your talk proposals in today!


### PR DESCRIPTION
This change adds a new blog post announcing the extension of our CFP. I
am also updating the original CFP post to note this extension in order
to avoid confusion.