### PR TITLE
Fix sponsosrs.yml Whitespace

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -113,7 +113,7 @@
     horizontal: /img/sponsors/FOSSlife/FOSSlife_portrait_rgb.png
     square:
   description: |-
-	  FOSSlife is dedicated to the world of free and open source software, focusing on careers, skills, and resources to help you build your future with FOSS. We provide timely information, useful insight, and practical resources for those who want to build or advance their career with open source. Subscribe to our weekly newsletter to get the latest from FOSSlife at https://www.fosslife.org/newsletter
+    FOSSlife is dedicated to the world of free and open source software, focusing on careers, skills, and resources to help you build your future with FOSS. We provide timely information, useful insight, and practical resources for those who want to build or advance their career with open source. Subscribe to our weekly newsletter to get the latest from FOSSlife at https://www.fosslife.org/newsletter
   sponsorships:
     2022: media
 


### PR DESCRIPTION
The site is currently failing to build due to the following error:

```
github-pages 227 | Error:  (/github/workspace/_data/sponsors.yml): found a tab character where an indentation space is expected while scanning a block scalar at line 115 column 16
```

This change fixes the whitespace.