### PR TITLE
Updated sponsors.yml

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -716,6 +716,7 @@
   sponsorships:
     2018: thanks
     2021: platinum
+    2022: bronze
 
 - name: twilio
   url: https://www.twilio.com/


### PR DESCRIPTION
Added JMP under bronze as they want to be a Non-exhibiting Sponsor.   Modeled off of MySQL last year (listed as bronze, but was non-exhibiting).