### PR TITLE
Publish 2022 Day 1 Schedule Blog Post

### DIFF
--- a/_posts/2022-11-04-day-1-schedule.md
+++ b/_posts/2022-11-04-day-1-schedule.md
@@ -18,9 +18,9 @@ Normal talk blocks are 30m. There are 20m for the talk, and 10m for optional Q&A
 
 All times are listed in Pacific Daylight Time, which is UTC-07:00. (Note: The US time change happens the evening AFTER the conclusion of the conference early on Sunday morning)
 
-### 9:00am-9:30am
-* 9:00am Opening Announcements
-* 9:10am Keynote by Aeva Black
+### 9:10am-9:35am
+* 9:10am Opening Announcements
+* 9:15am Keynote by Aeva Black
 
 #### 9:40am-10:10am
 * Alexander Krizhanovsky - Building a CDN edge using open source

--- a/_posts/2022-11-04-day-1-schedule.md
+++ b/_posts/2022-11-04-day-1-schedule.md
@@ -1,0 +1,60 @@
+---
+layout: post
+title: 'SeaGL 2022: DAY 1!'
+status: publish
+type: post
+published: true
+categories: news
+tags: '2022'
+---
+
+Welcome to the first day of SeaGL 2022! Be sure to check out our amazing [lineup of events](https://osem.seagl.org/conferences/seagl2022/schedule). Below, you will find the schedule for today (Friday, November 4, 2022). As a reminder, SeaGL 2022 is completely [virtual](https://seagl.org/news/2022/06/28/Virtual_SeaGL_2022.html) for the third year in a row. The conference is also completely "free as in tea" with no registration required. Everyone is welcome to attend!
+
+You can attend if you go to [seagl.org/attend](https://seagl.org/attend). Live streams are also available at [seagl.org/watch](https://seagl.org/watch).
+
+As a reminder, our [Code of Conduct](https://seagl.org/code_of_conduct.html) applies during ALL SeaGL interactions. In chat, during one's talk if you are giving one, social events during SeaGL, and on other platforms during or as a result of the conference.
+
+Normal talk blocks are 30m. There are 20m for the talk, and 10m for optional Q&A as led by the Room Moderator. The Moderator will read questions from the text chat audience for the speaker to answer. There is no Q&A during Keynotes.
+
+All times are listed in Pacific Daylight Time, which is UTC-07:00. (Note: The US time change happens the evening AFTER the conclusion of the conference early on Sunday morning)
+
+### 9:00am-9:30am
+* 9:00am Opening Announcements
+* 9:10am Keynote by Aeva Black
+
+#### 9:40am-10:10am
+* Alexander Krizhanovsky - Building a CDN edge using open source
+* Neslihan Turan - Struggles and possible solutions of a local free software movement
+
+#### 10:25am-10:55am
+* justinribeiro - Free-Riders and the Motivations that Keep OSS Developers Writing Code
+* der.hans - Intermediate jq: sed for json
+
+#### 11:10am-11:40am
+* Alanna Burke - The struggle of getting an open-source community off the ground
+* jberkus - The Cloud Native Burrito
+
+#### 11:55am-12:25pm
+* TheyofHIShirts - The Fediverse @ Your Library
+* vavroom - The internet is unusable: The disabled view.
+
+#### 1:30pm-2:00pm
+* Deb Nicholson - Cross-Pollinate Your Volunteering
+* Bradley Molinaro - Accessible Data Visualization
+
+#### 2:15pm-2:45pm
+* Dawn E. Collett - Finding the right tools for your new job
+* Richard Littauer - Gulls do gull: Using Node, D3, React and occasionally grep to get insight into bird subspecies distribution
+
+### 3:00pm-3:30pm
+* Afternoon TeaGL!
+
+#### 3:45pm-4:15pm
+* jberkus - Choose Your Candidate
+* der.hans - Firefox: Multi-Account Containers
+
+### 4:30pm-4:50pm
+* Keynote by Ernie Smitch
+
+### 5:30pm-6:00pm
+* Afternoon Trivia


### PR DESCRIPTION
This change adds a new blog post sharing the schedule for day 1 of SeaGL 2022