### PR TITLE
Publish 2022 Day 2 Schedule

### DIFF
--- a/_posts/2022-11-05-day-2-schedule.md
+++ b/_posts/2022-11-05-day-2-schedule.md
@@ -1,0 +1,59 @@
+---
+layout: post
+title: 'SeaGL 2022: DAY 2!'
+status: publish
+type: post
+published: true
+categories: news
+tags: '2022'
+---
+
+Welcome to the second and last day of SeaGL 2022! Be sure to check out our amazing [lineup of events](https://osem.seagl.org/conferences/seagl2022/schedule). Below, you will find the schedule for today (Saturday, November 5, 2022). As a reminder, SeaGL 2022 is completely [virtual](https://seagl.org/news/2022/06/28/Virtual_SeaGL_2022.html) for the third year in a row. The conference is also completely "free as in tea" with no registration required. Everyone is welcome to attend!
+
+You can attend if you go to [seagl.org/attend](https://seagl.org/attend). Live streams are also available at [seagl.org/watch](https://seagl.org/watch).
+
+As a reminder, our [Code of Conduct](https://seagl.org/code_of_conduct.html) applies during ALL SeaGL interactions. In chat, during one's talk if you are giving one, social events during SeaGL, and on other platforms during or as a result of the conference.
+
+Normal talk blocks are 30m. There are 20m for the talk, and 10m for optional Q&A as led by the Room Moderator. The Moderator will read questions from the text chat audience for the speaker to answer. There is no Q&A during Keynotes.
+
+All times are listed in Pacific Daylight Time, which is UTC-07:00. (Note: The US time change happens the evening AFTER the conclusion of the conference early on Sunday morning)
+
+### 9:30am-10:00am
+* 9:30am Opening Announcements
+* 9:35am Keynote by Lorena Mesa
+
+#### 10:00am-10:30am
+* Alanna Burke - The struggle of getting an open-source community off the ground
+* Atinuke Kayode - On Growth: Tips to Grow a Healthy Open Source Community
+
+#### 10:45am-11:15am
+* Aarti Ramkrishna - The Leaky Pipeline
+* Kaylea Champion - What's Anonymity Worth?
+
+#### 11:30am-12:00pm
+* Wm Salt Hale - Ten years of SeaGL
+
+#### 12:10pm-12:40pm
+* No-Cook Lunch Hour
+
+#### 1:25pm-1:55pm
+* Deb Nicholson - Grow Your FOSS Project with this One Weird Trick
+* Bob Murphy - A brief introduction to the Fediverse
+
+#### 2:10pm-2:40pm
+* Brian Peters - VDO - Virtual Data Optimizer
+* Brian Raiter - Programmer Culture: The Odd Phenomenon of Recreational Programming
+
+### 2:55pm-3:25pm
+* Bri Hatch - Tab completion for your custom commands
+* Adrian Cochrane - The Small Web
+
+#### 3:40pm-4:10pm
+* Matt McGraw - Self-hosting Simple Web Apps With Traefik and Docker Compose
+* Kaylea Champion - TIL 2022: FLOSS Research Roundup
+
+### 4:30pm-4:50pm
+* Keynote by Sumana Harihareswara
+
+### 5:30pm-6:00pm
+* Evening mock/cocktails


### PR DESCRIPTION
This change adds a new blog post publishing the 2022 Day 2 Schedule