### PR TITLE
Update Mastodon link for verification purposes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -102,7 +102,7 @@ custom:
             cfp-help:       <a href="mailto:%63%66%70%2D%68%65%6C%70%40%73%65%61%67%6C%2E%6F%72%67">&#x63;&#x66;&#x70;&#x2D;&#x68;&#x65;&#x6C;&#x70;&#x40;&#x73;&#x65;&#x61;&#x67;&#x6C;&#x2E;&#x6F;&#x72;&#x67;</a>
         social:
             github:         <a href="https://github.com/SeaGL/">GitHub</a>
-            mastodon:       <a href="https://mastodon.social/@SeaGL">Mastodon</a>
+            mastodon:       <a rel="me" href="https://mastodon.social/@SeaGL">Mastodon</a>
             pixelfed:       <a href="https://pixelfed.social/SeaGL">Pixelfed</a>
             twitter:        <a href="https://twitter.com/seagl">Twitter</a>
             facebook:       <a href="https://www.facebook.com/SeattleGnuLinuxConference">Facebook</a>


### PR DESCRIPTION
To verify our Mastodon account `@seagl@mastodon.social` we must include `rel=me` on the link
From mastodon profile:

`You can verify yourself as the owner of the links in your profile metadata. For that, the linked website must contain a link back to your Mastodon profile. After adding the link you may need to come back here and re-save your profile for the verification to take effect. The link back must have a rel="me" attribute. `