### PR TITLE
fixed logo on phones

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,6 +11,19 @@
 
   <a class="" href="/">
     <img src="/img/logo.svg" id="logo" alt="Logo" width="184" height="200">
+    <style>
+      /* default */
+      #logo {
+        max-width: 100%;
+      }
+
+      /* phones */
+      @media (max-width: 768px) {
+        #logo {
+          max-width: 80%;
+        }
+      }
+    </style>
   </a>
 
   <div id="main-nav-container" class="collapse navbar-collapse top-nav-collapse">


### PR DESCRIPTION
Noticed an error viewing changes on the phone (example photo uses dimension size of iPhone):

Before: 
<img width="371" alt="image" src="https://github.com/user-attachments/assets/99c89ba2-9142-4987-872d-aaa98a156683" />

After: 
<img width="375" alt="image" src="https://github.com/user-attachments/assets/04623e1a-a01f-4d58-a258-0e8dbce50139" />
