### PR TITLE
Correct aspect ratio of logo on narrow viewports

### DIFF
--- a/css/app/seagl.scss
+++ b/css/app/seagl.scss
@@ -352,6 +352,7 @@ p img {
     height: 170px;
     max-width: 30%;
     width: auto;
+    object-fit: contain;
   }
   #main-content {
     clear: both;


### PR DESCRIPTION
@theKimSingh Thanks for catching this. Look okay?

### Preview

> ![886e23b 480px](https://github.com/user-attachments/assets/5a7df916-9820-4994-aa65-395cc29f3557)

### Diff

480px:

> ![6661e70 vs 886e23b at 480px](https://github.com/user-attachments/assets/ba495b9e-2d0a-4763-8d3c-5c60c6603a62)

910px:

> ![6661e70 vs 886e23b at 910px](https://github.com/user-attachments/assets/7f7aee3f-d28c-47da-a5d5-948e65a5644f)

1200px:

> ![6661e70 vs 886e23b at 1200px](https://github.com/user-attachments/assets/7c41c930-c34d-4fdc-b21b-962644bd5d13)
