### PR TITLE
Publish schedule data as JSON

### DIFF
--- a/data/schedule.json
+++ b/data/schedule.json
@@ -1,0 +1,15 @@
+---
+---
+{% comment %}
+This data is used by Birdhouse to render stream monitoring controls at runtime.
+This data gets removed in the off-season, so in this case we simply render
+empty array (for no streams).
+
+See https://github.com/SeaGL/birdhouse
+{% endcomment %}
+
+{% if site.data.schedule.streams %}
+  {{ site.data.schedule.streams | jsonify }}
+{% else %}
+  []
+{% endif %}


### PR DESCRIPTION
I tested this with and without the scheduling YAML data removed in commit 670dffd4400d0f2c6d3b32d7b5025d25743a59e0.