### PR TITLE
SeaGL 2025 blog post for keynote abstracts

### DIFF
--- a/_posts/2025-09-25-keynote-abstracts.md
+++ b/_posts/2025-09-25-keynote-abstracts.md
@@ -1,0 +1,49 @@
+---
+layout: post
+title: 'Shining a spotlight onto the SeaGL keynote sessions'
+status: publish
+type: post
+published: true
+categories: news
+tags: '2025'
+---
+
+SeaGL is only 46 days away!  Yup, we're starting the countdown.
+As a treat this week, we have conjured up some keynote descriptions sent to us by our lovely keynoters!
+
+Keynotes will take place starting at 9am on both Friday and Saturday in the [Lyceum at the University of Washington HUB](/maps/2025).
+They will also be streamed live online for our remote attendees!
+
+## **Nadya Peek** presents: “Challenges When Building Open Source Hardware”
+
+_Friday, November 7th, 2025. 9:10 am_
+
+Manufacturing hardware (devices, machines, objects) is a challenging task. High-volume sales can offset costs of production, but niche products struggle with viability. Distributed production of open source designs---having people build their own niche products---is a possible alternative.
+In this talk, I will describe how digital fabrication like 3D printing, CNC milling, etc. can be used for distributed production and contrast that approach with centralized production. Through example open source hardware projects I will highlight design features that work well and less well, how community support is crucial for replication, and give recommendations for how to make more distributed production possible.
+
+_About the speaker:_ **Nadya Peek** (<https://www.hcde.washington.edu/peek/>), is an associate professor in the department of Human Centered Design & Engineering (HCDE) at the University of Washington.
+
+
+## **Allison Randal** presents: “The River Has Roots: Lessons in Open Source”
+
+_Friday, November 7th, 2025. 9:40 am_
+
+Open Source is software, hardware, a community, a development methodology, a resource, a charity, a business, a philosophy, and more than the sum of its parts. This reflection on decades of engagement in free and open source software and open hardware mixes a dash of history with an ounce of hope for the future.
+
+_About the speaker:_ **Allison Randal** [@allison@muon.social](https://muon.social/@allison), is a free software and open hardware developer and the chair of the board at Software Freedom Conservancy.
+
+## **Esther Jang** presents: “The Seattle Community Network Stack”
+
+_Saturday, November 8th, 2025. 9:10 am_
+
+The Seattle Community Network is a volunteer-based, grassroots, nonprofit community ISP with a small operating budget (currently averaging $10-$50K in grants, donations, or in-kind contributions per year) that installs and provides internet access for homeless shelters; the services we provide to our users is critical infrastructure for their daily lives. This talk discusses some of the core operational challenges we face, the software infrastructure we use to meet those challenges, and its limitations.
+
+_About the speaker:_ **Esther Jang** (https://estherjang.com/), she is the Director at the Local Connectivity Lab and founded the Seattle Community Network.
+
+## **Evan Prodromou** presents: “Free the Social Web”
+
+_Saturday, November 8th, 2025. 9:40 am_
+
+As Free and Open Source Software enthusiasts, we sometimes concentrate on our own experiences with software, hardware and data. But in the world of social networks, our own computing is deeply intertwined with that of our friends and family, colleagues and neighbours. Open Web standards let us stay connected to people that matter to us while using and building free, private, and technically enhanced systems. And we might even change some hearts and minds along the way!
+
+_About the speaker:_ **Evan Prodromou** [@evan@cosocial.ca](https://cosocial.ca/@evan), he is the Research Director at the Social Web Foundation, where he helps develop and promote the ActivityPub standard.


### PR DESCRIPTION
Adds blog post for SeaGL 2025 keynote presentations, descriptions, times and locations