### PR TITLE
Make a clearer link to site source code

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,7 @@
   </div>
 
   <div>
-    <p>All website code is licensed {{ site.custom.license.site_code }}. Unless otherwise specified, all website content is licensed {{ site.custom.license.content }}.</p>
+    <p>All <a href="https://github.com/SeaGL/seagl.github.io">website code</a> is licensed {{ site.custom.license.site_code }}. Unless otherwise specified, all website content is licensed {{ site.custom.license.content }}.</p>
   </div>
 
   <ul id="footer-nav" role="navigation" class="list-inline-delimited">


### PR DESCRIPTION
If you're just looking for a link to the site source code, it isn't super clear that the GPL link would link you there until you actually look at the link target, and even then it's annoying that it links you to the license file when you just wanted the repo root.

I considered putting something in `_config.yml` to match the rest of the file... but it seems like unnecessary indirection? And, it seems kind of awkward that the text that's in this link would be in the config file, which effectively couples these files. But then just putting in the URL felt kind of weird and inconsistent too.