### PR TITLE
Update /attend* for 2025

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,7 @@ exclude:
     - vendor/ruby/
 
 custom:
+    # For various reasons, `year` isn't used in decent swaths of the relevant text - so make sure to still grep around for the old year
     year:                   2025
     dates:                  November 7th & 8th
     location:               In-Person & Remote

--- a/attend.md
+++ b/attend.md
@@ -23,7 +23,7 @@ title: Attend SeaGL 2025
         <p>SeaGL takes place on the University of Washington campus at the Husky Union Building (known as the HUB).
             This is located on the central campus, west of Stevens Way NE.</p>
         <p>We recommend viewing the indoor map to get familiar with the general layout of the conference.</p>
-        <p><a class="btn btn-primary btn-large" href="/maps/2025">View Conference Maps</a></p>
+        <p><a class="btn btn-primary btn-large" href="{{ site.custom.url.location }}">View Conference Maps</a></p>
       </div>
     </div>
   </div>
@@ -55,7 +55,7 @@ title: Attend SeaGL 2025
 <div class="row" style="margin-bottom: 1em;margin-top: 2em;">
   <div class="col col-sm-6 col-md-5 col-md-offset-1 col-lg-4 col-lg-offset-2">
     <div class="panel panel-primary text-center">
-      <div class="panel-heading"><h2 class="panel-title">SeaGL 2025 Account</h2></div>
+      <div class="panel-heading"><h2 class="panel-title">SeaGL {{ site.custom.year }} Account</h2></div>
       <div class="panel-body">
         <p>We'll set you up with a Matrix account to attend. Your account will go away when the conference is over.</p>
         <p><a class="btn btn-primary btn-large" href="/attend/ephemeral">Take me to the conference</a></p>

--- a/attend/ephemeral.md
+++ b/attend/ephemeral.md
@@ -2,17 +2,17 @@
 layout: page
 redirect_from:
   - /attend-ephemeral
-title: Attend SeaGL 2024 Remotely
-description: How to attend SeaGL 2024 with an ephemeral Matrix account
+title: Attend SeaGL 2025 Remotely
+description: How to attend SeaGL 2025 with an ephemeral Matrix account
 ---
 
 # Attending SeaGL
 
 SeaGL uses a chat system called [Matrix] for the remote part of our hybrid conference. We've got things set up so Matrix is super easy to use for you - just follow these 3 steps. But if you _do_ run into any trouble, you can email <matrix-help@seagl.org> and we'll help you get it sorted out. <!-- TODO - possibly link to Kiwi IRC too. -->
 
-## Step 1 - get your 2024 account
+## Step 1 - get your {{ site.custom.year }} account
 
-The first step is to get a 2024 account! This won't require any of your personal information. Come back to this page after you're signed up.
+The first step is to get a {{ site.custom.year }} account! This won't require any of your personal information. Come back to this page after you're signed up.
 
 <div class="text-center">
   <p><a class="btn btn-primary btn-large" href="https://attend.seagl.org/#/register?hs=ephemeral">Get my account</a></p>
@@ -26,15 +26,15 @@ This is the home screen of SeaGL's version of [Element], an open source, free so
 
 <img class="align-center" alt="Screenshot of attend.seagl.org" src="/img/attend-portal.webp" />
 
-Some things to know about Matrix and your 2024 account:
+Some things to know about Matrix and your {{ site.custom.year }} account:
 
 1. Matrix is decentralized, which means that your account is “at” the provider of your choice, but you can communicate seamlessly across providers - similar to email.
-2. We're acting as the Matrix provider for the account you just made to attend SeaGL. Because your account is primarily intended for you to attend, it will be deleted on **November 17th** (one week after the end of the conference). Before that day, though, it will function as a full Matrix account. (Try joining the Matrix room of a free software project you hear about at the conference!) <!-- TODO it would be rad if we could actually see how many talks are about projects with Matrix rooms -->
+2. We're acting as the Matrix provider for the account you just made to attend SeaGL. Because your account is primarily intended for you to attend, it will be deleted on **November 16th** (one week after the end of the conference). Before that day, though, it will function as a full Matrix account. (Try joining the Matrix room of a free software project you hear about at the conference!) <!-- TODO it would be rad if we could actually see how many talks are about projects with Matrix rooms -->
 3. If you decide you like Matrix, we encourage you to get a permanent account and hang out in the [year-round SeaGL space](https://matrix.to/#/#SeaGL:seattlematrix.org)! There are lots of [options][Matrix options] for using Matrix, but we often recommend [Matrix*.org*][Matrix.org] as a service provider (since it's a public service operated by a non-profit) and [Element] as the client you use to get on Matrix (since it's open source and available on many platforms, including the web).
 
 ## Step 3 - have fun at SeaGL!
 
-We hope you enjoy hanging out with our flock this year. Our friendly Matrix bot, Patch, will help guide you around the conference. If you have any questions, please bring them up in the ["Welcome"]( https://attend.seagl.org/#/room/#2024-welcome:seagl.org) or ["Info Booth"]( https://attend.seagl.org/#/room/#2024-info-booth:seagl.org) rooms.
+We hope you enjoy hanging out with our flock this year. Our friendly Matrix bot, Patch, will help guide you around the conference. If you have any questions, please bring them up in the ["Hallway"]( https://attend.seagl.org/#/room/#2025-hallway:seagl.org) or ["Info Booth"]( https://attend.seagl.org/#/room/#2025-info-booth:seagl.org) rooms.
 
 As a reminder, participation in any SeaGL space is subject to our [Code of Conduct](/code_of_conduct).
 

--- a/attend/existing.md
+++ b/attend/existing.md
@@ -2,21 +2,21 @@
 layout: page
 redirect_from:
   - /attend-existing
-title: Attend SeaGL 2024 Remotely
-description: How to attend SeaGL 2024 with an existing Matrix account
+title: Attend SeaGL 2025 Remotely
+description: How to attend SeaGL 2025 with an existing Matrix account
 ---
 
 # Attend with your Matrix account
 
-The remote part of SeaGL's hybrid conference uses a Matrix homeserver operated by [Seattle Matrix](https://seattlematrix.org/). The whole conference is a series of rooms and subspaces in a Matrix space—it is primarily designed with [Element](https://element.io/)'s interface in mind. You can of course use your own preferred Matrix client—just bear in mind we won't be able to help you out as much.
+The remote part of SeaGL's hybrid conference uses a Matrix homeserver operated by [Seattle Matrix](https://seattlematrix.org/). The whole conference is a series of rooms and subspaces in a Matrix space, and is primarily designed with [Element](https://element.io/)'s interface in mind. You can of course use your own preferred Matrix client—just bear in mind we won't be able to help you out as much.
 
 Here's a button to get into the main conference space:
 
 <div class="text-center">
-  <p><a class="btn btn-primary btn-large" href="https://matrix.to/#/#SeaGL2024:seattlematrix.org">Join the SeaGL 2024 space</a></p>
+  <p><a class="btn btn-primary btn-large" href="https://matrix.to/#/#SeaGL2025:seattlematrix.org">Join the SeaGL {{ site.custom.year }} space</a></p>
 </div>
 
-Below are some tips on navigating the conference in Element. If you run into any trouble, you can always email <matrix-help@seagl.org> or find us in the [Info Booth](https://matrix.to/#/#2024-info-booth:seagl.org) room.
+Below are some tips on navigating the conference in Element. If you run into any trouble, you can always email <matrix-help@seagl.org> or find us in the [Info Booth](https://matrix.to/#/#2025-info-booth:seagl.org) room.
 
 As a reminder, participation in any SeaGL space is subject to our [Code of Conduct](/code_of_conduct).
 
@@ -31,7 +31,7 @@ We recommend you expand the sidebar for quicker access to the main space and sub
 
 <img class="align-center" alt="Screenshot of the top-left of the Element client pointing out the arrow directly to the right of the profile picture in the upper-left corner" src="/img/element-sidebar-arrow.webp" />
 
-Then hover over the SeaGL 2024 space—or a relevant subspace—and click the three dots menu, then "Space home":
+Then hover over the SeaGL {{ site.custom.year }} space—or a relevant subspace—and click the three dots menu, then "Space home":
 
 <img class="align-center" alt="Screenshot of the SeaGL space item in the Element left pane, with the three dots button at the right of the list item highlighted" src="/img/element-three-dots-menu.webp" />
 
@@ -40,7 +40,7 @@ Then hover over the SeaGL 2024 space—or a relevant subspace—and click the th
 
 SeaGL makes heavy use of Matrix widgets to provide the conference experience. In particular, widgets are how we embed video streams into Matrix rooms—enabling chat participation while watching the talks. Because of this, you may see quite a few permission prompts like this:
 
-<img class="align-center" alt="Screenshot of a widget prompt in Element - a box above the main chat window labeled Welcome to SeaGL 2024 with text that says 'Using this widget may share data with attend.seagl.org' and a button that says 'Continue'" src="/img/element-widget-prompt.webp" />
+<img class="align-center" alt="Screenshot of a widget prompt in Element - a box above the main chat window labeled Welcome to SeaGL {{ site.custom.year }} with text that says 'Using this widget may share data with attend.seagl.org' and a button that says 'Continue'" src="/img/element-widget-prompt.webp" />
 
 Please allow these widgets in order to experience the conference properly.
 
@@ -59,6 +59,6 @@ The audio and video call buttons in Element aren't used in the Matrix rooms wher
 
 One option that will solve the above caveats is to use our customized version of Element, available at [attend.seagl.org](https://attend.seagl.org). The reason we don't recommend this in the first place is because submitting your Matrix credentials into random websites is bad practice, and we don't want to encourage it. However, we're mentioning this option for completeness and would happily share our service.
 
-If you insist on using our version of Element—hopefully because you really _do_ trust the SeaGL staff with your Matrix credentials, visit [attend.seagl.org](https://attend.seagl.org/) and click "Sign In" under the "Create 2024 Account" button.
+If you insist on using our version of Element—hopefully because you really _do_ trust the SeaGL staff with your Matrix credentials, visit [attend.seagl.org](https://attend.seagl.org/) and click "Sign In" under the "Create {{ site.custom.year }} Account" button.
 
 To be clear, we have no intention to store, save, or otherwise misuse your credentials—but there are risk that we feel are important to share.


### PR DESCRIPTION
Note that I left the hardcoded year in the Matrix URLs because I figured that would help force us to double-check room names and such every year. I.e., theoretically these URLs aren't necessarily the same structure every year - already this year one of the URLs had to be updated besides `s/2024/2025/`.