### PR TITLE
Fix /watch having a weird title

### DIFF
--- a/watch.html
+++ b/watch.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: Watch
 nav: watch
 page_supports_jumbotron: true
 ---


### PR DESCRIPTION
Mostly I'm PR'ing this in case anyone thinks it should be "Watch only" or something.

But if you're already on this page... I guess it's fine. When the jumbotron is up that'll do a pretty good job discouraging using this page. `Watch | Seattle GNU/Linux Conference` is pretty good I think, I like that it's short.