### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/js/link_twitter_handles.js
+++ b/js/link_twitter_handles.js
@@ -2,7 +2,8 @@ $( window ).load(function() {
   $('.handle').each(function( index ) {
     if ($( this ).text()[0] == '@') {
         var handle = $( this ).text().substr(1);
-        $( this ).html('<a href="https://www.twitter.com/' + encodeURIComponent(handle) + '">@'+handle+'</a>');
+        var link = $('<a>').attr('href', 'https://www.twitter.com/' + encodeURIComponent(handle)).text('@' + handle);
+        $( this ).empty().append(link);
     }
   });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/SeaGL/seagl.github.io/security/code-scanning/1](https://github.com/SeaGL/seagl.github.io/security/code-scanning/1)

In general, fix this by avoiding `.html()` with concatenated untrusted data. Build the anchor element using jQuery/DOM methods, set `href` as an attribute, and set visible text with `.text()` so special characters are escaped automatically.

Best fix in `js/link_twitter_handles.js` (line 5 region): replace the `.html('<a ...>@'+handle+'</a>')` construction with creation of an `<a>` node via `$('<a>')`, assign:
- `href: 'https://www.twitter.com/' + encodeURIComponent(handle)`
- link text via `.text('@' + handle)`

Then clear/replace the current element content safely using `.empty().append(link)`. This preserves current behavior (same rendered link) while removing HTML reinterpretation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
